### PR TITLE
Fixed import in CfxPinnedServers

### DIFF
--- a/src/models/CfxPinnedServers.ts
+++ b/src/models/CfxPinnedServers.ts
@@ -1,4 +1,4 @@
-import { CfxPinnedServersResponse } from "src/types/CfxPinnedServers"
+import { CfxPinnedServersResponse } from "../types/CfxPinnedServers"
 
 export default class CfxPinnedServers {
     pinIfEmpty: boolean


### PR DESCRIPTION
Building a project with `npx tsc` failed due to: 

```
 npx tsc                         

node_modules/cfx-api/dist/models/CfxPinnedServers.d.ts:1:42 - error TS2307: Cannot find module 'src/types/CfxPinnedServers' or its corresponding type declarations.
                                                                                                                                                                   
1 import { CfxPinnedServersResponse } from "src/types/CfxPinnedServers";                                                                                           
                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                            


Found 1 error in node_modules/cfx-api/dist/models/CfxPinnedServers.d.ts:1
```

Modifying the import to use `..` instead of `src` seems to be working :)


`package.json`:
```json
{
  "name": "xxxxx",
  "version": "1.0.0",
  "description": "xxxxx",
  "scripts": {
    "build": "npx tsc",
    "test": "jest --coverage",
    "test:ci": "jest --coverage --ci"
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "dependencies": {
    "cfx-api": "^1.2.0",
    "discord-webhook-node": "^1.1.8",
    "typescript": "next"
  },
  "devDependencies": {
    "@types/jest": "^29.5.3",
    "@types/node": "^20.8.10",
    "jest": "^29.7.0",
    "jest-junit": "^16.0.0",
    "ts-jest": "^29.1.1"
  }
}
```

Output from CI/CD build (which is the same as local)
```
yarn install v1.22.19
[1/4] Resolving packages...
(node:2) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 4.44s.
yarn run v1.22.19
$ npx tsc
node_modules/cfx-api/dist/models/CfxPinnedServers.d.ts(1,[42](https://git.r3ktm8.de/SeaLife-Docker/fivem-player-tracker/-/jobs/141537#L42)): error TS2307: Cannot find module 'src/types/CfxPinnedServers' or its corresponding type declarations.
npm notice 
npm notice New minor version of npm available! 10.2.4 -> 10.4.0
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.4.0>
npm notice Run `npm install -g npm@10.4.0` to update!
npm notice 
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: building at STEP "RUN yarn install && yarn build": while running runtime: exit status 2
```